### PR TITLE
Stop Level One music on scene shutdown

### DIFF
--- a/njitfall2025/src/game/scenes/LevelOneScene.ts
+++ b/njitfall2025/src/game/scenes/LevelOneScene.ts
@@ -4,6 +4,7 @@ export class LevelOneScene extends Phaser.Scene {
     private shermingsGroup!: Phaser.Physics.Arcade.Group;
     private walls!: Phaser.Physics.Arcade.StaticGroup;
     private spawnTimer?: Phaser.Time.TimerEvent;
+    private backgroundMusic?: Phaser.Sound.BaseSound;
 
 
     constructor() {
@@ -68,13 +69,20 @@ export class LevelOneScene extends Phaser.Scene {
             }
         });
 
+        const stopMusic = () => {
+            if (this.backgroundMusic) {
+                this.backgroundMusic.stop();
+                this.backgroundMusic.destroy();
+                this.backgroundMusic = undefined;
+            }
+        };
+
         this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => {
             this.spawnTimer?.remove(false);
-            //STOP music when scene shuts down 
-            if  (this.backgroundMusic) {
-                this.backgroundMusic.stop();
-            }
+            stopMusic();
         });
+
+        this.events.once(Phaser.Scenes.Events.DESTROY, stopMusic);
 
         if (!this.anims.exists('sherming_walk_right')) {
             this.anims.create({


### PR DESCRIPTION
## Summary
- add a stored background music reference for the Level One scene
- stop and destroy the Mainmenuv2 track when the scene shuts down or is destroyed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e037196cc08326bdbdf659559b7290