### PR TITLE
Add music and button sounds to level selection scene

### DIFF
--- a/njitfall2025/src/game/scenes/LevelSelectionScene.ts
+++ b/njitfall2025/src/game/scenes/LevelSelectionScene.ts
@@ -4,27 +4,88 @@ import Phaser from 'phaser';
 
 export class LevelSelectionScene extends Phaser.Scene {
 
+    private backgroundMusic?: Phaser.Sound.BaseSound;
+    private hoverSound?: Phaser.Sound.BaseSound;
+    private clickSound?: Phaser.Sound.BaseSound;
+
     constructor() {
         super('LevelSelection');
     }
 
+    preload() {
+        this.load.audio('level_selection_music', new URL('../assets/music/Firstlevel.mp3', import.meta.url).href);
+        this.load.audio('button_hover', new URL('../assets/sounds/selectingsound.mp3', import.meta.url).href);
+        this.load.audio('button_click', new URL('../assets/sounds/Pressingbutton.mp3', import.meta.url).href);
+    }
+
     create() {
+        this.backgroundMusic = this.sound.add('level_selection_music', { loop: true, volume: 0.5 });
+        this.backgroundMusic.play();
+
+        this.hoverSound = this.sound.add('button_hover');
+        this.clickSound = this.sound.add('button_click');
+
         const mainMenuButton = new TexturedButton(this, this.scale.width / 2, this.scale.height / 2, 120, 40, 'Main Menu', null, TextStyles.BUTTON_TEXT);
 
+        mainMenuButton.backGround.on('pointerover', () => this.playHoverSound());
         mainMenuButton.backGround.on('pointerdown', () => {
+            this.playClickSound();
             this.scene.start('MainMenu');
             console.log('Switched to main menu');
         });
 
         const levelOneButton = new TexturedButton(this, this.scale.width / 2, this.scale.height / 2 + 41, 120, 40, 'Start Level 1', null, TextStyles.BUTTON_TEXT);
 
+        levelOneButton.backGround.on('pointerover', () => this.playHoverSound());
         levelOneButton.backGround.on('pointerdown', () => {
+            this.playClickSound();
             this.scene.start('LevelOne');
             console.log('Switched to level One');
         });
 
+        this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => this.cleanupAudio());
+        this.events.once(Phaser.Scenes.Events.DESTROY, () => this.cleanupAudio());
+
         this.add.existing(mainMenuButton);
         this.add.existing(levelOneButton);
+    }
+
+    private playHoverSound() {
+        if (!this.hoverSound) {
+            return;
+        }
+
+        this.hoverSound.stop();
+        this.hoverSound.play();
+    }
+
+    private playClickSound() {
+        if (!this.clickSound) {
+            return;
+        }
+
+        this.clickSound.stop();
+        this.clickSound.play();
+    }
+
+    private cleanupAudio() {
+        if (this.backgroundMusic) {
+            this.backgroundMusic.stop();
+            this.backgroundMusic.destroy();
+            this.backgroundMusic = undefined;
+        }
+
+        if (this.hoverSound) {
+            this.hoverSound.stop();
+            this.hoverSound.destroy();
+            this.hoverSound = undefined;
+        }
+
+        if (this.clickSound) {
+            this.clickSound.stop();
+            this.clickSound.destroy();
+            this.clickSound = undefined;
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- load background music and button sound effects for the level selection scene
- play looping music on scene creation and clean it up on shutdown
- trigger hover and click audio feedback on level selection buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04ccd560c832697cef8fb687cae68