### PR TITLE
Stop tracking first level background asset

### DIFF
--- a/njitfall2025/.gitignore
+++ b/njitfall2025/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.vscode/
+.DS_Store


### PR DESCRIPTION
## Summary
- remove the checked-in first_level.png so the change set contains only text-based updates while keeping the scene code unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e053b5583c8326a3db2d215a773dac